### PR TITLE
Route the trailing-slash account path to container.List

### DIFF
--- a/internal/webserver/engine.go
+++ b/internal/webserver/engine.go
@@ -81,6 +81,7 @@ func EchoEngine(ctrl Controller) *echo.Echo {
 		db:     ctrl.Database,
 	}
 	swift.GET("", container.List, auth)
+	swift.GET("/", container.List, auth) // tolerate a trailing slash (/v1/AUTH_x/)
 	swift.HEAD("/:container", container.Show, auth) // check existence
 	swift.GET("/:container", container.Show, auth)
 	swift.PUT("/:container", container.Create, auth)


### PR DESCRIPTION
Clients (e.g. openstack4j) request the account/container listing as /v1/AUTH_<account>/ with a trailing slash, which returned 404 because only the slash-less route was registered.  Register container.List for both forms.