### PR TITLE
Apply delimiter roll-up to container listings

### DIFF
--- a/internal/webserver/container_handler.go
+++ b/internal/webserver/container_handler.go
@@ -112,13 +112,15 @@ func (h *container) Show(c echo.Context) error {
 	case http.MethodHead:
 		return c.NoContent(http.StatusOK)
 	case http.MethodGet:
-		prefix := c.Request().Header.Get("prefix")
+		prefix := c.QueryParam("prefix")
+		delimiter := c.QueryParam("delimiter")
 
 		if c.Request().Header.Get("Accept") == "text/plain" {
 			return c.String(http.StatusOK, serializer.TextObjects(objects, prefix))
 		}
 		// "application/json"
-		return c.JSON(http.StatusOK, serializer.Objects(objects, prefix))
+		return c.JSON(http.StatusOK,
+			serializer.ObjectsWithDelimiter(objects, prefix, delimiter))
 	}
 	return weberror.New(http.StatusNotFound, swift.BadRequest.Text)
 }

--- a/internal/webserver/serializer/object.go
+++ b/internal/webserver/serializer/object.go
@@ -21,12 +21,36 @@ func TextObjects(objects []*model.Object, prefix string) string {
 
 // Objects returns the serialized form of the given models.
 func Objects(objects []*model.Object, prefix string) []map[string]interface{} {
+	return ObjectsWithDelimiter(objects, prefix, "")
+}
+
+// ObjectsWithDelimiter serializes the listing, applying Swift's delimiter
+// roll-up: object keys that contain the delimiter after the prefix are
+// collapsed into deduplicated {"subdir": "<prefix + segment up to and
+// including the delimiter>"} entries, and only keys without the delimiter
+// are returned as objects.  An empty delimiter lists every object.
+func ObjectsWithDelimiter(objects []*model.Object, prefix, delimiter string) []map[string]interface{} {
 	sl := make([]map[string]interface{}, 0, len(objects))
+	seen := make(map[string]bool)
 
 	for _, object := range objects {
-		if strings.HasPrefix(object.Key, prefix) {
-			sl = append(sl, Object(object))
+		if !strings.HasPrefix(object.Key, prefix) {
+			continue
 		}
+
+		if delimiter != "" {
+			rest := object.Key[len(prefix):]
+			if idx := strings.Index(rest, delimiter); idx >= 0 {
+				subdir := prefix + rest[:idx+len(delimiter)]
+				if !seen[subdir] {
+					seen[subdir] = true
+					sl = append(sl, map[string]interface{}{"subdir": subdir})
+				}
+				continue
+			}
+		}
+
+		sl = append(sl, Object(object))
 	}
 
 	return sl


### PR DESCRIPTION
A Swift container listing with a delimiter collapses keys that share a prefix-up-to-the-delimiter into deduplicated {"subdir": "..."} entries.  container.Show ignored the delimiter (and read the prefix from a request header rather than the query), so listings were always flat.  Read prefix/delimiter from the query and roll up subdirs in the serializer.