### PR TITLE
Strip the leading slash when parsing container/object paths

### DIFF
--- a/internal/xpath/path.go
+++ b/internal/xpath/path.go
@@ -13,6 +13,11 @@ func Entities(p string) (container, object string) {
 		p = cp
 	}
 
+	// Swift's X-Copy-From and Destination headers are conventionally written
+	// with a leading slash ("/container/object"); drop it so the container is
+	// not parsed as an empty segment.
+	p = strings.TrimPrefix(p, "/")
+
 	artifacts := strings.Split(p, "/")
 	if len(artifacts) < 2 {
 		return artifacts[0], ""


### PR DESCRIPTION
Swift's X-Copy-From and Destination headers are conventionally written as "/container/object" with a leading slash.  xpath.Entities split on "/" without trimming it, so the leading empty segment became the container name and every copy resolved to a missing container (404).

Trim a leading slash before splitting; inputs without one (built via path.Join) are unaffected.