### PR TITLE
Honor the marker query parameter when listing objects

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -39,7 +39,7 @@ type (
 	// A ObjectInteraction defines all the methods used to interact with a object record.
 	ObjectInteraction interface {
 		AllObjects() ([]*model.Object, error)
-		FindObjectsByContainerID(id string, limit int, prefix string) ([]*model.Object, error)
+		FindObjectsByContainerID(id string, limit int, prefix, marker string) ([]*model.Object, error)
 		FindObjectsByManifestID(id string) ([]*model.Object, error)
 		FindObjectByKey(cid, key string) (*model.Object, error)
 		DeleteObject(id string) error

--- a/internal/database/storm.go
+++ b/internal/database/storm.go
@@ -128,14 +128,23 @@ func (c *strm) AllObjects() ([]*model.Object, error) {
 	return objects, errors.Wrap(err, "could not get all objects")
 }
 
-func (c *strm) FindObjectsByContainerID(id string, limit int, prefix string) ([]*model.Object, error) {
+func (c *strm) FindObjectsByContainerID(id string, limit int, prefix, marker string) ([]*model.Object, error) {
 	objects := make([]*model.Object, 0)
 	if (limit == 0) {
 		limit = -1
 	}
 	// prefix is a literal object-name prefix (Swift listing semantics), not a regexp,
 	// so escape any regexp metacharacters before anchoring it with "^".
-	err := c.db.Select(q.Eq("ContainerID", id), q.Re("Key", "^" + regexp.QuoteMeta(prefix))).Limit(limit).OrderBy("Key").Find(&objects)
+	matchers := []q.Matcher{
+		q.Eq("ContainerID", id),
+		q.Re("Key", "^" + regexp.QuoteMeta(prefix)),
+	}
+	// marker (Swift listing pagination): return only objects whose key sorts
+	// strictly after it, so the limit applies to the page that follows.
+	if marker != "" {
+		matchers = append(matchers, q.Gt("Key", marker))
+	}
+	err := c.db.Select(matchers...).Limit(limit).OrderBy("Key").Find(&objects)
 	return objects, errors.Wrap(err, "could not get objects by container_id")
 }
 

--- a/internal/webserver/container_handler.go
+++ b/internal/webserver/container_handler.go
@@ -72,7 +72,7 @@ func (h *container) Show(c echo.Context) error {
 
 	h.logger.Debugf("container Show: container %v limit=%v prefix=%v", c.Param("container"), limit, c.QueryParam("prefix"))
 
-	objects, err := h.db.FindObjectsByContainerID(container.ID, limit, c.QueryParam("prefix"))
+	objects, err := h.db.FindObjectsByContainerID(container.ID, limit, c.QueryParam("prefix"), c.QueryParam("marker"))
 
 	/*
 	// Delimiter spliter maybe can be removed
@@ -196,7 +196,7 @@ func (h *container) Delete(c echo.Context) error {
 
 	//
 
-	objects, err := h.db.FindObjectsByContainerID(container.ID, 1, "")
+	objects, err := h.db.FindObjectsByContainerID(container.ID, 1, "", "")
 	if err != nil && !h.db.IsNotFound(err) {
 		return weberror.New(http.StatusInternalServerError, err.Error())
 	}


### PR DESCRIPTION
Object listings ignored the Swift "marker" parameter: the container Show handler passed only the limit and prefix to the database, so paginating clients (which set marker to the last key they saw) always received the first page again.

Thread marker through FindObjectsByContainerID and, when set, restrict the query to keys sorting strictly after it (q.Gt on the indexed Key field) so the limit applies to the page that follows.