### PR TITLE
Return an empty list instead of 500 on an empty database

### DIFF
--- a/internal/database/storm.go
+++ b/internal/database/storm.go
@@ -98,6 +98,12 @@ func (c *strm) IsNotFound(err error) bool {
 func (c *strm) ListContainers() ([]*model.Container, error) {
 	containers := make([]*model.Container, 0)
 	err := c.db.AllByIndex("Name", &containers)
+	if c.IsNotFound(err) {
+		// Unlike All, AllByIndex returns ErrNotFound when the Container
+		// bucket does not exist yet, i.e. on a fresh database before the
+		// first Save.  Report an empty account instead of an error.
+		return containers, nil
+	}
 	return containers, errors.Wrap(err, "could not get all containers")
 }
 

--- a/tests/00_list_test.go
+++ b/tests/00_list_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListContainersEmptyDatabase(t *testing.T) {
+	c, cleanup := setup()
+	defer cleanup()
+
+	ctx := context.Background()
+	err := c.Authenticate(ctx)
+	assert.NoError(t, err)
+
+	//
+
+	containers, err := c.Containers(ctx, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, containers)
+}


### PR DESCRIPTION
storm's `AllByIndex` returns ErrNotFound when the bucket itself does not exist, which is the case on a fresh database: `swift server` opens the database without running `init`, and storm only creates the bucket on the first Save. `ListContainers` thus responded 500 on a fresh server -- breaking any client that lists containers before creating one, such as the ceph s3-tests cleanup fixture, which lists buckets at the start of every test. Treat ErrNotFound as an empty account, as the object handlers already do via IsNotFound.

`All`, by contrast, returns no error and an empty slice even when the bucket is missing, so `AllObjects` needs no special handling.
