### PR TITLE
Persist and return container access-control headers

### DIFF
--- a/internal/webserver/container_handler.go
+++ b/internal/webserver/container_handler.go
@@ -167,7 +167,13 @@ func (h *container) Update(c echo.Context) error {
 
 	// Create and update metadata
 	for key, values := range c.Request().Header {
-		if (!strings.HasPrefix(key, "X-Container-Meta-") && len(values) > 0 ) {
+		if len(values) == 0 {
+			continue
+		}
+		// Persist user metadata along with the read/write access-control
+		// headers so that container ACLs survive a round-trip.
+		if !strings.HasPrefix(key, "X-Container-Meta-") &&
+			key != "X-Container-Read" && key != "X-Container-Write" {
 			continue
 		}
 		// no string to mark only container


### PR DESCRIPTION
The container metadata handler only stored X-Container-Meta-* headers, so the X-Container-Read and X-Container-Write access-control headers were silently dropped -- never persisted and never returned -- leaving a container's read ACL unable to survive a round-trip.

Also persist the X-Container-Read and X-Container-Write headers (and skip headers carrying no value) so that a container set to public-read still reports as such on a later HEAD.