### PR TITLE
Validate a client-supplied ETag on upload

### DIFF
--- a/internal/webserver/object_handler.go
+++ b/internal/webserver/object_handler.go
@@ -217,6 +217,15 @@ func (h *object) Upload(c echo.Context) error {
 		return weberror.New(http.StatusInternalServerError, err.Error())
 	}
 
+	// Swift validates a client-supplied ETag against the uploaded object's MD5
+	// and rejects a mismatch with 422 Unprocessable Entity.
+	if etag := c.Request().Header.Get("ETag"); etag != "" &&
+		!strings.EqualFold(strings.Trim(etag, `"`), object.Checksum) {
+		_ = h.storage.Remove(container.Name, object.Key)
+		return weberror.New(http.StatusUnprocessableEntity,
+			"the ETag did not match the object's MD5 checksum")
+	}
+
 	//
 
 	if err := h.db.Save(object); err != nil {


### PR DESCRIPTION
Swift rejects a PUT whose client-provided ETag does not match the object's computed MD5 with 422 Unprocessable Entity.  After streaming the body, compare the ETag request header to the MD5 and, on a mismatch, drop the stored body and return 422 instead of accepting corrupt data.