### PR TITLE
Replace container metadata on update instead of accumulating

### DIFF
--- a/internal/webserver/container_handler.go
+++ b/internal/webserver/container_handler.go
@@ -184,6 +184,13 @@ func (h *container) Update(c echo.Context) error {
 // storeContainerMeta persists the request's X-Container-Meta-* headers and the
 // read/write access-control headers (X-Container-Read/Write) as container
 // metadata, so container ACLs survive a round-trip on both create and update.
+//
+// Each key is replaced rather than added to.  AddMeta always saves a new
+// record, so without the delete a second write left two rows for the one key
+// and a read answered with whichever row the store returned last -- ordered by
+// the random ID assigned on save, so clearing an ACL appeared to work only
+// about half the time.  Only the keys the request carries are touched, since a
+// Swift POST updates the metadata it names and leaves the rest alone.
 func (h *container) storeContainerMeta(c echo.Context, container *model.Container) error {
 	for key, values := range c.Request().Header {
 		if len(values) == 0 {
@@ -192,6 +199,10 @@ func (h *container) storeContainerMeta(c echo.Context, container *model.Containe
 		if !strings.HasPrefix(key, "X-Container-Meta-") &&
 			key != "X-Container-Read" && key != "X-Container-Write" {
 			continue
+		}
+		if err := h.db.DeleteMeta(container.ID, "", key); err != nil &&
+			!h.db.IsNotFound(err) {
+			return err
 		}
 		if _, err := h.db.AddMeta(container.ID, "", key, values[0]); err != nil {
 			return err

--- a/tests/05_meta_test.go
+++ b/tests/05_meta_test.go
@@ -42,6 +42,43 @@ func TestUpdateMetaContainer(t *testing.T) {
 
 }
 
+// Writing a key twice must replace the first value rather than add to it.  The
+// store saves a new record per write, so without a delete the container kept
+// two rows for the one key and a read answered with whichever came back last --
+// ordered by the random ID assigned on save, which gave an even chance of
+// reading either.  Several containers run so that outcome cannot pass by luck.
+func TestUpdateMetaContainerReplacesPreviousValue(t *testing.T) {
+	c, cleanup := setup()
+	defer cleanup()
+
+	ctx := context.Background()
+	err := c.Authenticate(ctx)
+	assert.NoError(t, err)
+
+	for i := 0; i < 16; i++ {
+		name := fmt.Sprintf("Xcontainer%d", i)
+
+		// the ACL arrives on the create, the metadata on a later update
+		err = c.ContainerCreate(ctx, name, swift.Headers{"X-Container-Read": ".r:*"})
+		assert.NoError(t, err)
+		err = c.ContainerUpdate(ctx, name,
+			swift.Metadata{"color": "orange"}.ContainerHeaders())
+		assert.NoError(t, err)
+
+		// clearing the ACL and overwriting the metadata must both stick
+		err = c.ContainerUpdate(ctx, name, swift.Headers{"X-Container-Read": ""})
+		assert.NoError(t, err)
+		m := swift.Metadata{"color": "blue"}
+		err = c.ContainerUpdate(ctx, name, m.ContainerHeaders())
+		assert.NoError(t, err)
+
+		_, headers, err := c.Container(ctx, name)
+		assert.NoError(t, err)
+		assert.Equal(t, m, headers.ContainerMetadata())
+		assert.Empty(t, headers["X-Container-Read"])
+	}
+}
+
 func TestUpdateMetaObject(t *testing.T) {
 	c, cleanup := setup()
 	defer cleanup()


### PR DESCRIPTION
storeContainerMeta only added the request's headers, and AddMeta saves a new record every call, so writing a key twice left two rows for it.  A read set the response header from each row in turn, ordered by the random ID assigned on save, so the newer value won only about half the time: clearing a container ACL with X-Container-Read took effect or did not, at random.

Drop the existing rows for each key the request carries before persisting it.  Only the keys named in the request are touched, since a Swift POST updates the metadata it names and leaves the rest alone, which is why this cannot reuse the wholesale DeleteAllMetas that storeObjectMeta relies on.

The test walks several containers because a single one would have had an even chance of reading the newer row and passing over the bug.